### PR TITLE
Update epitope.py to import sys

### DIFF
--- a/epitope/epitope.py
+++ b/epitope/epitope.py
@@ -3,6 +3,7 @@ import copy
 import re
 import logging
 import itertools
+import sys
 from collections import OrderedDict
 
 import numpy as np


### PR DESCRIPTION
When there are no mutations translated it currently gives an error:
```
File "/root/main/neoag-tools.py", line 174, in <module>
args.func(args)
File "/root/main/epitope/epitope.py", line 250, in run
sys.exit(0)
NameError: name 'sys' is not defined
```

As sys is not imported in the script `epitope.py`